### PR TITLE
adjust required version of env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ winapi = "0.2.8"
 [dependencies]
 rand = "0.3"
 log = "0.3"
-env_logger = "0.4.1"
+env_logger = "0.4"
 libc = "^0.2"
 boxfnonce = "0.0.3"
 runloop = "0.1.0"


### PR DESCRIPTION
Precisely specifying `env_logger`'s version down to the patch number causes unnecessary issues when vendoring crates: crates that specify "0.4" for `env_logger` will vendor the newest version (0.4.3 at the time of this writing), while this crate will vendor 0.4.1.

Let's just relax the required version of `env_logger` for this crate to bring it in line with everything else.